### PR TITLE
feat: #7 implement beep sound class with default tone

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 # Contributors
 
 * **Daniel Tait** - *Project Owner* - [Taiters](https://github.com/Taiters)
+* **Megherea Eugeniu** - *Contributor* - [eugeniumegherea](https://github.com/eugeniumegherea)
 * ..You?

--- a/src/cpu/cpu.js
+++ b/src/cpu/cpu.js
@@ -2,7 +2,7 @@ import {opcode} from 'chip8/cpu/opcode.js';
 import {execute} from 'chip8/cpu/instructions';
 import keyboard from 'chip8/cpu/keyboard.js';
 import font from 'chip8/cpu/font.js';
-
+import beep from 'chip8/sound/beep.js';
 class Cpu {
     constructor(display) {
         this.display = display;
@@ -42,10 +42,12 @@ class Cpu {
         if (this.state.delay > 0)
             this.state.delay--;
 
-        if (this.state.sound > 0)
+        if (this.state.sound > 0) {          
+            beep.play();
             this.state.sound--;
+        }
     }
-
+    
     load(romData) {
         this.reset();
         this.state.mem.set(romData, this.state.pc);

--- a/src/sound/beep.js
+++ b/src/sound/beep.js
@@ -1,0 +1,23 @@
+class BeepSound {
+    constructor() {
+        this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+
+    play() {
+        var oscillator = this.audioCtx.createOscillator();
+
+        oscillator.type = 'square';
+        oscillator.frequency.setValueAtTime(440, this.audioCtx.currentTime);
+        oscillator.connect(this.audioCtx.destination);
+
+        oscillator.start();
+        oscillator.stop(this.audioCtx.currentTime + 0.0166667);
+        // the sound will play for 16.6667 milliseconds (the duration of a frame)
+    }
+
+}
+
+// Sound will be a singleton
+const instance = new BeepSound();
+
+export default instance;


### PR DESCRIPTION
# Description
Create a class which implements a beep sound. When you call method `play()` the sound will play for the duration of the frame (16ms).

Fixes (#7)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
