### PR TITLE
improve readability of disassembler UI

### DIFF
--- a/src/components/disassembler.js
+++ b/src/components/disassembler.js
@@ -11,7 +11,9 @@ const Disassembler = (props) => {
     const lines = props.disassembledRom.map((line, i) => {
         return (
             <p key={i}>
-                0x{line.address.toString(16)}: {line.instruction}
+                <span class={styles.address}>
+                    0x{line.address.toString(16)}:
+                </span> {line.instruction}
             </p>
         );
     });

--- a/src/styles/disassembler.scss
+++ b/src/styles/disassembler.scss
@@ -1,4 +1,22 @@
+@import 'chip8/styles/colors.scss';
+
 :local(.container) {
     height: 100%;
     width: 100%;
+}
+
+:local(.container > p) {
+    margin-block-end: 0em;
+    margin-block-start: 0em;
+    padding-block-end: 0.5em;
+    padding-block-start: 0.5em;
+}
+
+:local(.container > p:nth-child(even)) {
+    background-color: $text;
+    color: $background;
+}
+
+:local(span.address) {
+    font-size: 0.75em;
 }


### PR DESCRIPTION
# Description

Implemented changes in instruction list UI @Taiters  requested in issue #6. Specifically, I made the text size of the address smaller and alternated the background/text color in adjacent rows of instructions. How does this look? Also, sorry if my code does not following best practices, I am new to using SCSS.

Fixes #6 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

![chip8-ui](https://user-images.githubusercontent.com/35127144/47124467-ab193d80-d243-11e8-9689-c31fcc34333a.png)

