### PR TITLE
Tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,4 +2,5 @@
 
 * **Daniel Tait** - *Project Owner* - [Taiters](https://github.com/Taiters)
 * **Megherea Eugeniu** - *Contributor* - [eugeniumegherea](https://github.com/eugeniumegherea)
+* **Nima Afzal Ahangaran** - *Contributor* - [nimvb](https://github.com/nimvb)
 * ..You?

--- a/src/app/instructions/operations.js
+++ b/src/app/instructions/operations.js
@@ -142,7 +142,7 @@ export default {
     shl: (state, opcode) => {
         state.registers = state.registers.slice(0);
         const vy = state.registers[opcode.vy];
-        const mostSignificantBit = (vy & 0x8000) >> 15;
+        const mostSignificantBit = (vy & 0x0080) >> 7;
         state.registers[0x0F] = mostSignificantBit;
         state.registers[opcode.vx] = (vy << 1) & 0xFF;
         state.pc += 2;
@@ -163,8 +163,8 @@ export default {
     },
 
     jumpToAddressV0: (state, opcode) => {
-        state.i = opcode.nnn + state.registers[0x0];
-        state.pc += 2;
+        const jmp = opcode.nnn + state.registers[0x0];
+        state.pc = jmp;
         return state;
     },
 
@@ -284,6 +284,7 @@ export default {
             const register = state.registers[i];
             state.mem[state.i + i] = register;
         }
+        state.i = state.i + vx + 1;
         state.pc += 2;
         return state;
     },
@@ -295,6 +296,7 @@ export default {
             const value = state.mem[state.i + i];
             state.registers[i] = value;
         }
+        state.i = state.i + vx + 1;
         state.pc += 2;
         return state;
     }

--- a/tests/.eslintrc.yaml
+++ b/tests/.eslintrc.yaml
@@ -1,0 +1,6 @@
+extends: ../.eslintrc.yml
+env:
+    jest: true
+
+globals:
+   global: true

--- a/tests/app/instructions.test.js
+++ b/tests/app/instructions.test.js
@@ -170,6 +170,732 @@ describe('execute', () => {
             expect(result.pc).toEqual(0x202);
         });
     });
+
+    describe('0x6xnn: ld vx, byte', () => {
+        test('loads byte value into vx', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x6023));
+
+            expect(result.registers).toEqual([
+                0x23, 
+                0x1, 
+                0x8, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x7xnn: add vx, byte', () => {
+        test('adds byte into vx', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x70ff));
+
+            expect(result.registers).toEqual([
+                0x2, 
+                0x1, 
+                0x8, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy0: ld vx, vy', () => {
+        test('loads value of vy into vx', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x8020));
+
+            expect(result.registers).toEqual([
+                0x8, 
+                0x1, 
+                0x8, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy1: or vx, vy', () => {
+        test('loads result of bitwise ORing of vx and vy into vx', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x8021));
+
+            expect(result.registers).toEqual([
+                0xb, 
+                0x1, 
+                0x8, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy2: and vx, vy', () => {
+        test('loads result of bitwise ANDing of vx and vy into vx', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x8022));
+
+            expect(result.registers).toEqual([
+                0x0, 
+                0x1, 
+                0x8, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy3: xor vx, vy', () => {
+        test('loads result of bitwise XORing of vx and vy into vx', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x8023));
+
+            expect(result.registers).toEqual([
+                0xB, 
+                0x1, 
+                0x8, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy4: add vx, vy', () => {
+        test('sets vf to 1 if a carry occurs', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[0] = 241;
+            registers[2] = 15;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8024));
+
+            expect(result.registers[0]).toEqual(0);
+            expect(result.registers[2]).toEqual(15);
+            expect(result.registers[15]).toEqual(1);
+            expect(result.pc).toEqual(0x202);
+        });
+
+        test('sets vf to 0 if a carry does not occur', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[0] = 240;
+            registers[2] = 15;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8024));
+
+            expect(result.registers[0]).toEqual(255);
+            expect(result.registers[2]).toEqual(15);
+            expect(result.registers[15]).toEqual(0);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy5: sub vx, vy', () => {
+        test('Sets vf to 0 if a borrow occurs', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[0] = 0;
+            registers[2] = 1;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8025));
+
+            expect(result.registers[0]).toEqual(255);
+            expect(result.registers[2]).toEqual(1);
+            expect(result.registers[15]).toEqual(0);
+            expect(result.pc).toEqual(0x202);
+        });
+
+        test('Sets vf to 1 if a borrow does not occur', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[0x00] = 0x0F;
+            registers[0x02] = 0x0F;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8025));
+
+            expect(result.registers[0x00]).toEqual(0x00);
+            expect(result.registers[0x02]).toEqual(0x0F);
+            expect(result.registers[0x0F]).toEqual(0x01);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy6: shr vx, vy', () => {
+        test('stores the value of vy shifted right one bit in vx and vf to the least significant bit prior to the shift', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[2] = 3;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8026));
+
+            expect(result.registers[0]).toEqual(1);
+            expect(result.registers[2]).toEqual(3);
+            expect(result.registers[15]).toEqual(1);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xy7: subn vx, vy', () => {
+        test('sets vx to the value of vy - vx and sets vf to 0 if a borrow occurs', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[0] = 1;
+            registers[2] = 0;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8027));
+
+            expect(result.registers[0]).toEqual(0xFF);
+            expect(result.registers[2]).toEqual(0);
+            expect(result.registers[15]).toEqual(0);
+            expect(result.pc).toEqual(0x202);
+        });
+
+        test('sets vx to the value of vy - vx and sets vf to 0 if a borrow dose not occur', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[0] = 15;
+            registers[2] = 15;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x8027));
+
+            expect(result.registers[0]).toEqual(0);
+            expect(result.registers[2]).toEqual(15);
+            expect(result.registers[15]).toEqual(1);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x8xye: shl vx, vy', () => {
+        test('stores the value of vy shifted left one bit in vx and vf to the most significant bit prior to the shift', () => {
+
+            let registers = Array(16).fill(0);
+
+            registers[2] = 0xF0;
+
+            const result = execute({
+                registers: registers,
+                pc: 0x200,
+            }, createOpcode(0x802E));
+
+            expect(result.registers[0]).toEqual(224);
+            expect(result.registers[2]).toEqual(240);
+            expect(result.registers[15]).toEqual(1);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0x9xy0: sne vx, vy', () => {
+        test('skips if vx != vy', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x9210));
+
+            expect(result.pc).toEqual(0x204);
+        });
+
+        test('dose not skip if vx == vy', () => {
+            const result = execute({
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0x9230));
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xAnnn: ld i, addr', () => {
+        test('stores addr in register i', () => {
+            const result = execute({
+                i: 0,
+                pc: 0x200,
+            }, createOpcode(0xA2EF));
+
+            expect(result.i).toEqual(0x2EF);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xBnnn: jp v0, addr', () => {
+        test('sets pc to (V0 + addr)', () => {
+            const result = execute({
+               
+                registers: [0x0F],
+                pc: 0x200,
+            }, createOpcode(0xB400));
+
+            expect(result.pc).toEqual(0x40F);
+        });
+    });
+
+    describe('0xCxnn: rnd vx, byte', () => {
+        test('sets vx to a random number with a mask of byte', () => {
+
+            const globalMath = Object.create(global.Math);
+            const mockMath = Object.create(global.Math);
+            mockMath.random = () => {
+                let rnd = 0.4;
+                return rnd;
+            };
+            global.Math = mockMath;
+
+            const result = execute({
+                registers: [15],
+                pc: 0x200,
+            }, createOpcode(0xC0F0));
+
+            global.Math = globalMath;
+
+            expect(result.registers[0]).toEqual(96);
+            expect(result.pc).toEqual(0x202);
+        });
+    });
+
+    describe('0xDxyn: draw vx, vy, n', () => {
+        test('sets vf to 1 if any set pixels are changed', () => {
+
+            let expectedGfx =
+                Array.from(new Array(32),
+                    () => Array.from(new Array(8),
+                        () => Array.from(new Array(8),
+                            () => 1))).map(
+                    (_, index, array) => {
+                        if (index < 15) {
+                            (array[index][1]) = Array.from(new Array(8), () => 0);
+                        }
+                        return array[index];
+                    });
+
+            const flatten = array => {
+                while (array.find(element => Array.isArray(element))) array = Array.prototype.concat(...array);
+                return array;
+            };
+
+            expectedGfx = flatten(expectedGfx);
+
+            const state = {
+                registers: [
+                    8,
+                    0
+                ],
+                i: 0,
+                gfx: new Array(64 * 32),
+                mem: new Array(8 * 32),
+                drawFlag: false,
+                pc: 0x200,
+            };
+            state.gfx.fill(1);
+            state.mem.fill(255);
+            
+
+            const result = execute(state, createOpcode(0xD01F));
+
+            expect(result.gfx).toEqual(expectedGfx);
+            expect(result.drawFlag).toBe(true);
+            expect(result.registers[0]).toEqual(8);
+            expect(result.registers[1]).toEqual(0);
+            expect(result.registers[15]).toEqual(1);
+            expect(result.pc).toEqual(0x202);
+        });
+
+        test('does not set vf to 1 if any set pixels are not changed', () => {
+
+            let expectedGfx =
+                Array.from(new Array(32),
+                    () => Array.from(new Array(8),
+                        () => Array.from(new Array(8),
+                            () => 1)));
+
+            const flatten = array => {
+                while (array.find(element => Array.isArray(element))) array = Array.prototype.concat(...array);
+                return array;
+            };
+
+            expectedGfx = flatten(expectedGfx);
+
+            const state = {
+                registers: [
+                    8,
+                    0
+                ],
+                i: 0,
+                gfx: new Array(64 * 32),
+                mem: new Array(8 * 32),
+                drawFlag: false,
+                pc: 0x200,
+            };
+            state.gfx.fill(1);
+            state.mem.fill(0);
+            
+
+            const result = execute(state, createOpcode(0xD01F));
+
+            expect(result.gfx).toEqual(expectedGfx);
+            expect(result.drawFlag).toBe(true);
+            expect(result.registers[0]).toEqual(8);
+            expect(result.registers[1]).toEqual(0);
+            expect(result.registers[15]).toEqual(0);
+            expect(result.pc).toEqual(0x202);
+        });
+    });
+
+    describe('0xEx9E: skp vx', () => {
+        test('skips if keys[vx] is pressed', () => {
+            const result = execute({
+                registers: [0],
+                keys: [1],
+                pc: 0x200,
+            }, createOpcode(0xE09E));
+
+
+            expect(result.registers[0]).toEqual(0);
+            expect(result.pc).toEqual(0x204);
+        });
+
+        test('dose not skip if keys[vx] is not pressed', () => {
+            const result = execute({
+                registers: [0],
+                keys: [0],
+                pc: 0x200,
+            }, createOpcode(0xE09E));
+
+
+            expect(result.registers[0]).toEqual(0);
+            expect(result.pc).toEqual(0x202);
+        });
+    });
+
+    describe('0xExA1: sknp vx', () => {
+        test('skips if keys[vx] is not pressed', () => {
+            const result = execute({
+                registers: [0],
+                keys: [0],
+                pc: 0x200,
+            }, createOpcode(0xE0A1));
+
+
+            expect(result.registers[0]).toEqual(0);
+            expect(result.pc).toEqual(0x204);
+        });
+
+        test('dose not skip if keys[vx] is pressed', () => {
+            const result = execute({
+                registers: [0],
+                keys: [1],
+                pc: 0x200,
+            }, createOpcode(0xE0A1));
+
+
+            expect(result.registers[0]).toEqual(0);
+            expect(result.pc).toEqual(0x202);
+        });
+    });
+
+    describe('0xFx07: ld vx, dt', () => {
+        test('loads value of dt into vx', () => {
+            const result = execute({
+                delay: 0x10,
+                registers: [
+                    0x3, 
+                    0x1, 
+                    0x8, 
+                    0x8, 
+                    0x24, 
+                    0x12
+                ],
+                pc: 0x200,
+            }, createOpcode(0xF207));
+
+            expect(result.registers).toEqual([
+                0x3, 
+                0x1, 
+                0x10, 
+                0x8, 
+                0x24, 
+                0x12
+            ]);
+
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx0A: ld vx, K', () => {
+        test('Waits for keypress and loads result in vx', () => {
+            const result = execute({
+                waitKeyRegister: 2,
+                waitKeyFlag: false,
+                pc: 0x200,
+            }, createOpcode(0xF10A));
+
+            expect(result.waitKeyRegister).toEqual(1);
+            expect(result.waitKeyFlag).toEqual(true);
+            expect(result.pc).toEqual(0x200);
+        });
+
+    });
+
+    describe('0xFx15: ld dt, vx', () => {
+        test('sets value of vx to dt', () => {
+            const result = execute({
+                delay: 0x10,
+                registers: [
+                    0x3, 
+                    0x1, 
+                ],
+                pc: 0x200,
+            }, createOpcode(0xF015));
+
+            expect(result.delay).toEqual(0x3);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx18: ld st, vx', () => {
+        test('sets value of vx to st', () => {
+            const result = execute({
+                sound: 16,
+                registers: [
+                    3, 
+                    1, 
+                ],
+                pc: 0x200,
+            }, createOpcode(0xF018));
+
+            expect(result.sound).toEqual(3);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx1E: add i, vx', () => {
+        test('adds value of vx to i register', () => {
+            const result = execute({
+                i:0x400,
+                registers: [
+                    3, 
+                    1, 
+                ],
+                pc: 0x200,
+            }, createOpcode(0xF01E));
+
+            expect(result.i).toEqual(0x403);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx29: ld f, vx', () => {
+        test('loads address of font f in i register base on vx value', () => {
+            const result = execute({
+                i:0x400,
+                registers: [
+                    0x50, 
+                    0x1, 
+                ],
+                pc: 0x200,
+            }, createOpcode(0xF029));
+
+            expect(result.i).toEqual(0x190);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx33: ld b, vx', () => {
+        test('stores BCD representation of vx in memory addresses referenced by i, i+1 and i+2', () => {
+            const result = execute({
+                i:0,
+                mem: [
+                    0,
+                    0,
+                    0 
+                ],
+                registers: [
+                    256, 
+                    1, 
+                ],
+                pc: 0x200,
+            }, createOpcode(0xF033));
+
+            expect(result.mem).toEqual([2, 5, 6]);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx55: ld i, vx', () => {
+        test('stores values of v0-vx in memory from i to i+x and sets i to i+x+1', () => {
+            
+            const regs = Array.from(Array(16).keys());
+            const mem = Array.from(Array(16), () => 0);
+
+            const result = execute({
+                i:0,
+                mem: mem,
+                registers: regs,
+                pc: 0x200,
+            }, createOpcode(0xFF55));
+
+            expect(result.i).toEqual(16);
+            expect(result.mem).toEqual(regs);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+    describe('0xFx65: ld vx, i', () => {
+        test('fills registers v0-vx with values in memory from i to i+x and sets i to i+x+1', () => {
+            
+            const regs = Array.from(Array(16), () => 0);
+            const mem = Array.from(Array(16).keys());
+
+            const result = execute({
+                i:0,
+                mem: mem,
+                registers: regs,
+                pc: 0x200,
+            }, createOpcode(0xFF65));
+
+            expect(result.i).toEqual(16);
+            expect(result.registers).toEqual(mem);
+            expect(result.pc).toEqual(0x202);
+        });
+
+    });
+
+
+
+
 });
 
 describe('toString', () => {

--- a/tests/app/instructions.test.js
+++ b/tests/app/instructions.test.js
@@ -418,7 +418,7 @@ describe('execute', () => {
     });
 
     describe('0x8xy6: shr vx, vy', () => {
-        test('stores the value of vy shifted right one bit in vx and vf to the least significant bit prior to the shift', () => {
+        test('stores the value of vy shifted right one bit in vx and sets vf to the least significant bit prior to the shift', () => {
 
             let registers = Array(16).fill(0);
 
@@ -477,7 +477,7 @@ describe('execute', () => {
     });
 
     describe('0x8xye: shl vx, vy', () => {
-        test('stores the value of vy shifted left one bit in vx and vf to the most significant bit prior to the shift', () => {
+        test('stores the value of vy shifted left one bit in vx and sets vf to the most significant bit prior to the shift', () => {
 
             let registers = Array(16).fill(0);
 


### PR DESCRIPTION
# Description

I have added the remaining test for the operations. During writing unit tests I encountered with problems in the implementation of some operations which decline the expectations from the operations based on the documentation referenced for Chip-8 instructions in issue #10.

Followings are brief explanations for the problems I encountered during writing unit tests:

* shl

Consider the value `0xF0` which it's binary representation equals to `11110000`. In the code, to extract the value of the most significant bit(MSB), the value of the `vy` is stored in a variable larger than the register. Therefore, the result of ANDing `0x8000` with `0xF0` is going to be the value `0000000011110000` which results in a wrong answer.

* jumpToAddressV0

As mentioned in the [documentation](http://mattmik.com/files/chip8/mastering/chip8.html) instruction `BNNN` updates `pc` to `NNN+V0`, but instead the value of the register `i` is updated.

* loadV0VxIntoI and loadIIntoV0Vx

Again, based on the [documentation](http://mattmik.com/files/chip8/mastering/chip8.html), after those operations, the value of the register `i` should be set to `i + x + 1`

Fixes #10 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
